### PR TITLE
Fix initial state

### DIFF
--- a/viz/main.py
+++ b/viz/main.py
@@ -74,6 +74,10 @@ cv2.setMouseCallback('image',drawLoc)
 img = np.zeros((dim,dim,3), np.uint8)
 
 params = np.zeros((4,), float)
+params[0] = 0
+params[1] = 0
+params[2] = dim//2
+params[3] = dim//2
 inc = 10
 while(1):
     cv2.imshow('image', img)


### PR DESCRIPTION
# Summary
Fixes the initial state of the display so that a blank image is not shown
<img width="1136" alt="Screenshot 2022-12-14 at 11 48 00 PM" src="https://user-images.githubusercontent.com/39728574/207774995-b99d0a16-544a-491c-9dde-9a82939f8662.png">

